### PR TITLE
add ability to force a hook through the hook helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /libpeerconnection.log
 npm-debug.log
 testem.log
+lcov.info

--- a/README.md
+++ b/README.md
@@ -54,4 +54,10 @@ If you're unit testing your components, `ember-hook` won't be able to access you
 const component = this.subject({ forceHook: true });
 ```
 
+The above will force the component's hook to render. If you want to force a hook inside your component, you can pass `true` in as a second argument to the `hook` helper:
+
+```hbs
+<div class='arnt-i-pretty' data-test={{hook 'foo' forceHook}}>bar</div>
+```
+
 Note that this will eventually be depricated as the Ember community transitions to using integration tests for their components.

--- a/addon/helpers/hook.js
+++ b/addon/helpers/hook.js
@@ -5,8 +5,9 @@ const { Helper } = Ember;
 
 export default Helper.extend({
   compute(params) {
+    const [hookName, forceHook] = params;
     const config = this.container.lookupFactory('config:environment');
 
-    return returnWhenTesting(config, params[0]);
+    return returnWhenTesting(config, hookName, forceHook);
   }
 });

--- a/lcov.info
+++ b/lcov.info
@@ -52,10 +52,14 @@ end_of_record
 SF:addon/helpers/hook.js
 DA:1,1
 DA:5,1
-DA:7,1
+DA:7,5
 DA:9,1
 DA:11,1
 DA:13,1
-LF:6
-LH:6
+DA:15,1
+DA:16,1
+DA:18,1
+DA:20,1
+LF:10
+LH:10
 end_of_record


### PR DESCRIPTION
@Ticketfly/frontenders 

The previous PR allows you to force a component hook, but not a helper hook. This fixes that inconsistency.