### PR TITLE
use an exposed initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,7 @@ Use the `hook` helper to define your data attribute:
 Or the `hook` attribute in your component:
 
 ```js
-import { HookMixin } from 'ember-hook';
-
-export default Ember.Component.extend(HookMixin, {
+export default Ember.Component.extend({
   hook: 'foo'
 });
 ```
@@ -34,7 +32,15 @@ export default Ember.Component.extend(HookMixin, {
 Then in your tests:
 
 ```js
-import { hook, $hook } from 'ember-hook';
+import { initialize, hook, $hook } from 'ember-hook';
+
+moduleForComponent('my component', 'Integration | Component | my component', {
+  integration: true,
+
+  beforeEach() {
+    initialize();
+  }
+});
 
 . . . .
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,8 +1,10 @@
-import { hook, $hook } from './test-helpers/hook';
 import HookMixin from './mixins/hook';
+import { hook, $hook } from './test-helpers/hook';
+import { initialize } from './initializers/ember-hook/initialize';
 
 export {
-  hook,
+  HookMixin,
   $hook,
-  HookMixin
+  hook,
+  initialize
 };

--- a/addon/initializers/ember-hook/initialize.js
+++ b/addon/initializers/ember-hook/initialize.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+import HookMixin from '../../mixins/hook';
+
+const { Component } = Ember;
+
+export function initialize() {
+  Component.reopen(HookMixin);
+}
+
+export default {
+  name: 'ember-hook/initialize',
+  initialize: initialize
+};

--- a/app/initializers/ember-hook/initialize.js
+++ b/app/initializers/ember-hook/initialize.js
@@ -1,0 +1,1 @@
+export { default, initialize } from 'ember-hook/initializers/ember-hook/initialize';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-hook",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Yerrr tests be brittle, mattie!!!",
   "directories": {
     "doc": "doc",

--- a/tests/unit/initializers/ember-hook/initialize-test.js
+++ b/tests/unit/initializers/ember-hook/initialize-test.js
@@ -1,0 +1,27 @@
+import Ember from 'ember';
+import { initialize } from 'ember-hook';
+import { module, test } from 'qunit';
+
+var registry, application;
+
+module('Unit | Initializer | ember hook/initialize', {
+  beforeEach: function() {
+    Ember.run(function() {
+      application = Ember.Application.create();
+      registry = application.registry;
+      application.deferReadiness();
+    });
+  }
+});
+
+test('applies the `HookMixin` to `Component`', function(assert) {
+  assert.expect(2);
+
+  initialize();
+
+  const { Component } = Ember;
+  const component = Component.create({ hook: 'foo' });
+
+  assert.deepEqual(component.get('attributeBindings'), ['ariaRole:role', '_hookName:data-test'], 'adds _hookName to the attributeBindings');
+  assert.equal(component.get('_hookName'), 'foo', 'adds the _hookName computed');
+});


### PR DESCRIPTION
@Ticketfly/frontenders @pzuraq 

Currently, the hook logic is applied to components via a mixin. There are a few problems with this approach, including the fact that it makes hooking into external components much more complicated--including `{{input}}` and `{{textarea}}`.

Previously, we had used an initializer, which applied the hook logic to all components, including `input` and `textarea`. The problem with this approach was that initializers do not fire before integration tests, which meant that `ember-hook` could not be utilized in those contexts.

This PR returns us to our original approach of using an initializer, but now also exposes the initializer so it can be manually executed before integration tests start.