### PR TITLE
make ember-get-config a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-hook",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Yerrr tests be brittle, mattie!!!",
   "directories": {
     "doc": "doc",
@@ -35,7 +35,6 @@
     "ember-data": "^2.5.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
-    "ember-get-config": "0.0.3",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "ember-try": "^0.2.2",
@@ -45,7 +44,8 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6"
+    "ember-cli-babel": "^5.1.6",
+    "ember-get-config": "0.0.3"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
@Ticketfly/frontenders 

`ember-hook` depends on `ember-get-config`, but that dep got made into a devDep during the [upgrade to Ember 2.5](https://github.com/Ticketfly/ember-hook/commit/bc7f0975179d28d1d7fc9745e8226203b5c0bc34). This moves it back to where it belongs.