### PR TITLE
add the delimiter to the base hook

### DIFF
--- a/addon/helpers/hook.js
+++ b/addon/helpers/hook.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import config from 'ember-get-config';
 import decorateHook from 'ember-hook/utils/decorate-hook';
+import delimit from 'ember-hook/utils/delimit';
 import returnWhenTesting from 'ember-hook/utils/return-when-testing';
 
 const { Helper } = Ember;
@@ -9,6 +10,6 @@ export default Helper.extend({
   compute(params, qualifiers = {}) {
     const [hook] = params;
 
-    return returnWhenTesting(config, decorateHook(hook, qualifiers));
+    return returnWhenTesting(config, decorateHook(delimit(hook), qualifiers));
   }
 });

--- a/addon/mixins/hook.js
+++ b/addon/mixins/hook.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import config from 'ember-get-config';
+import delimit from 'ember-hook/utils/delimit';
 import returnWhenTesting from 'ember-hook/utils/return-when-testing';
 
 const {
@@ -17,7 +18,7 @@ export default Mixin.create({
     get() {
       const hook = get(this, hookName);
 
-      return returnWhenTesting(config, hook);
+      return returnWhenTesting(config, delimit(hook));
     }
   }).readOnly()
 });

--- a/addon/test-helpers/hook.js
+++ b/addon/test-helpers/hook.js
@@ -1,8 +1,9 @@
 import Ember from 'ember';
 import decorateHook from 'ember-hook/utils/decorate-hook';
+import delimit from 'ember-hook/utils/delimit';
 
 export function hook(name, qualifiers = {}) {
-  const hookQuery = `[data-test^="${name}"]`;
+  const hookQuery = `[data-test^="${delimit(name)}"]`;
 
   return decorateHook(hookQuery, qualifiers, (text) => `[data-test*="${text}"]`);
 }

--- a/addon/utils/delimit.js
+++ b/addon/utils/delimit.js
@@ -1,0 +1,5 @@
+import delimiter from 'ember-hook/utils/delimiter';
+
+export default function delimit(base) {
+  return `${base}${delimiter}`;
+}

--- a/addon/utils/delimiter.js
+++ b/addon/utils/delimiter.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+import config from 'ember-get-config';
+
+const { get } = Ember;
+
+export default get(config, 'emberHook.delimiter') || '&^%^&';

--- a/addon/utils/generate-qualifier.js
+++ b/addon/utils/generate-qualifier.js
@@ -1,10 +1,5 @@
-import Ember from 'ember';
-import config from 'ember-get-config';
-
-const { get } = Ember;
-
-const delimiter = get(config, 'emberHook.delimiter') || '&^%^&';
+import delimit from 'ember-hook/utils/delimit';
 
 export default function generateQualifier(object, key) {
-  return `${delimiter}${key}=${object[key]}`;
+  return delimit(`${key}=${object[key]}`);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-hook",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Yerrr tests be brittle, mattie!!!",
   "directories": {
     "doc": "doc",

--- a/tests/acceptance/hook-test.js
+++ b/tests/acceptance/hook-test.js
@@ -14,7 +14,7 @@ module('Acceptance | hook', {
 });
 
 test('visiting /', function(assert) {
-  assert.expect(6);
+  assert.expect(8);
 
   visit('/');
 
@@ -27,5 +27,8 @@ test('visiting /', function(assert) {
     assert.equal($hook('letter').length, 5, 'gathers all instances when no qualifiers are provided');
     assert.equal($hook('letter', { groupIndex: 0 }).length, 2, 'gathers all instances that satisfy the qualifier');
     assert.equal($hook('letter', { index: 1, groupIndex: 1 }).text().trim(), 'D', 'gathers the instance that satisfies multiple qualifiers');
+
+    assert.equal($hook('half').text().trim(), 'half', 'grabs half');
+    assert.equal($hook('half_and_half').text().trim(), 'half and half', 'grabs half_and_half');
   });
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -3,3 +3,6 @@
 {{test-component hook="component-hook" text="Component"}}
 
 {{alphabet-component}}
+
+<p data-test={{hook "half"}}>half</p>
+<p data-test={{hook "half_and_half"}}>half and half</p>

--- a/tests/unit/initializers/ember-hook/initialize-test.js
+++ b/tests/unit/initializers/ember-hook/initialize-test.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import { initialize } from 'ember-hook';
 import { module, test } from 'qunit';
+import delimiter from 'ember-hook/utils/delimiter';
 
 var registry, application;
 
@@ -23,5 +24,5 @@ test('applies the `HookMixin` to `Component`', function(assert) {
   const component = Component.create({ hook: 'foo' });
 
   assert.deepEqual(component.get('attributeBindings'), ['ariaRole:role', '_hookName:data-test'], 'adds _hookName to the attributeBindings');
-  assert.equal(component.get('_hookName'), 'foo', 'adds the _hookName computed');
+  assert.equal(component.get('_hookName'), `foo${delimiter}`, 'adds the _hookName computed');
 });

--- a/tests/unit/utils/decorate-hook-test.js
+++ b/tests/unit/utils/decorate-hook-test.js
@@ -1,4 +1,5 @@
 import decorateHook from 'ember-hook/utils/decorate-hook';
+import delimiter from 'ember-hook/utils/delimiter';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | decorate hook');
@@ -8,7 +9,7 @@ test('it decorates the hook with qualifiers', function(assert) {
 
   const result = decorateHook('foo', { bar: 'baz', aff: 'arf', zap: 'zork' });
 
-  assert.equal(result, 'foo&^%^&aff=arf&^%^&bar=baz&^%^&zap=zork', 'decorates with sorted key value pairs');
+  assert.equal(result, `fooaff=arf${delimiter}bar=baz${delimiter}zap=zork${delimiter}`, 'decorates with sorted key value pairs');
 });
 
 test('it wraps the content if a callback is provided', function(assert) {
@@ -16,5 +17,5 @@ test('it wraps the content if a callback is provided', function(assert) {
 
   const result = decorateHook('foo', { bar: 'baz', aff: 'arf', zap: 'zork' }, (text) => `<${text}>`);
 
-  assert.equal(result, 'foo<&^%^&aff=arf><&^%^&bar=baz><&^%^&zap=zork>', 'wrapped correctly');
+  assert.equal(result, `foo<aff=arf${delimiter}><bar=baz${delimiter}><zap=zork${delimiter}>`, 'wrapped correctly');
 });

--- a/tests/unit/utils/delimit-test.js
+++ b/tests/unit/utils/delimit-test.js
@@ -1,0 +1,13 @@
+import delimit from 'ember-hook/utils/delimit';
+import delimiter from 'ember-hook/utils/delimiter';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | delimit');
+
+test('it appends the delimiter to a string', function(assert) {
+  assert.expect(1);
+
+  const result = delimit('foo');
+
+  assert.equal(result, `foo${delimiter}`, 'generates the correct string');
+});

--- a/tests/unit/utils/generate-qualifier-test.js
+++ b/tests/unit/utils/generate-qualifier-test.js
@@ -1,4 +1,5 @@
 import generateQualifier from 'ember-hook/utils/generate-qualifier';
+import delimiter from 'ember-hook/utils/delimiter';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | generate qualifier');
@@ -9,5 +10,5 @@ test('it returns the correct qualifier', function(assert) {
   const object = { foo: 'bar', baz: 'boozle' };
   const result = generateQualifier(object, 'foo');
 
-  assert.equal(result, '&^%^&foo=bar', 'generates the correct qualifier');
+  assert.equal(result, `foo=bar${delimiter}`, 'generates the correct qualifier');
 });


### PR DESCRIPTION
@Ticketfly/frontenders 

Found a bug with `1.1.0`. Basically, if I have this:

```hbs
<p data-test={{hook "half"}}>half</p>
<p data-test={{hook "half_and_half"}}>half and half</p>
```

Then:

```js
$hook('half');
```

Will return the `half_and_half` paragraph. This pr fixes that.