### PR TITLE
Add option for always being enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,31 @@ var ENV ={
   }
 }
 ```
+
+### Enabling ember-hook outside of the test environment
+
+`ember-hook` by default is only enabled when the environment is `test`.  If you need to force ember-hook to be enabled in other environments, or always on, you can use `enabled`.
+
+```js
+// config/environment.js
+
+var ENV ={
+  emberHook: {
+    enabled: true
+  }
+}
+```
+
+```js
+// config/environment.js
+module.exports = function(environment) {
+  var ENV ={
+    emberHook: {
+      // only enable in test or production builds
+      enabled: environment === 'production'
+    }
+  }
+
+  // ...
+}
+```

--- a/addon/utils/return-when-testing.js
+++ b/addon/utils/return-when-testing.js
@@ -1,5 +1,11 @@
+import Ember from 'ember';
+
+const { get } = Ember;
+
 export default function returnWhenTesting(config, value) {
-  if (config.environment === 'test') {
+  const enabled = get(config, 'emberHook.enabled');
+
+  if (typeof enabled === 'boolean' ? enabled : config.environment === 'test') {
     return value;
   }
 }


### PR DESCRIPTION
This adds the ability to force ember-hook to be enabled even when the environment is not `test`.  Our usecase is we run selenium tests outside of a test environment and would like to use the same stable selectors that ember-hook provides.