### PR TITLE
_hookName should only return when there is a hook present

### DIFF
--- a/addon/mixins/hook.js
+++ b/addon/mixins/hook.js
@@ -17,8 +17,10 @@ export default Mixin.create({
   _hookName: computed(hookName, {
     get() {
       const hook = get(this, hookName);
-
-      return returnWhenTesting(config, delimit(hook));
+      
+      if (hook) {
+        return returnWhenTesting(config, delimit(hook));
+      }
     }
   }).readOnly()
 });


### PR DESCRIPTION
Currently this will return `data-test="undefined&^%^&"`