### PR TITLE
Added development environment to the default and a test to verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ var ENV ={
 
 ### Enabling ember-hook outside of the test environment
 
-`ember-hook` by default is only enabled when the environment is `test`.  If you need to force ember-hook to be enabled in other environments, or always on, you can use `enabled`.
+`ember-hook` by default is enabled when the environment is `test` or `development`.  If you need to force ember-hook to be enabled in other environments, or always on, you can use `enabled`.
 
 ```js
 // config/environment.js

--- a/addon/utils/return-when-testing.js
+++ b/addon/utils/return-when-testing.js
@@ -5,7 +5,7 @@ const { get } = Ember;
 export default function returnWhenTesting(config, value) {
   const enabled = get(config, 'emberHook.enabled');
 
-  if (typeof enabled === 'boolean' ? enabled : config.environment === 'test') {
+  if (typeof enabled === 'boolean' ? enabled : config.environment === 'test' || config.environment === 'development') {
     return value;
   }
 }

--- a/tests/unit/utils/return-when-testing-test.js
+++ b/tests/unit/utils/return-when-testing-test.js
@@ -3,6 +3,11 @@ import { module, test } from 'qunit';
 
 module('Unit | Utility | test environment');
 
+test('it returns the second argument if the first has a development environment', function(assert) {
+  const result = returnWhenTesting({ environment: 'development' }, 'foo');
+  assert.equal(result, 'foo');
+});
+
 test('it returns the second argument if the first has a test environment', function(assert) {
   const result = returnWhenTesting({ environment: 'test' }, 'foo');
   assert.equal(result, 'foo');


### PR DESCRIPTION
Added "development" environment as an additional default
Added test to validate that "development" is a valid environment
Updated README to reflect that the default environments are "test" and "development"

Closes: https://github.com/Ticketfly/ember-hook/issues/19

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ticketfly/ember-hook/20)
<!-- Reviewable:end -->
