### PR TITLE
fix failing beta test

### DIFF
--- a/tests/unit/initializers/ember-hook/initialize-test.js
+++ b/tests/unit/initializers/ember-hook/initialize-test.js
@@ -23,6 +23,6 @@ test('applies the `HookMixin` to `Component`', function(assert) {
   const { Component } = Ember;
   const component = Component.create({ hook: 'foo' });
 
-  assert.deepEqual(component.get('attributeBindings'), ['ariaRole:role', '_hookName:data-test'], 'adds _hookName to the attributeBindings');
+  assert.ok(component.get('attributeBindings').indexOf('_hookName:data-test') > -1, 'adds _hookName to the attributeBindings');
   assert.equal(component.get('_hookName'), `foo${delimiter}`, 'adds the _hookName computed');
 });


### PR DESCRIPTION
@Ticketfly/frontenders

In Ember 2.8, they're removing `ariaRole:role` from the default `attributeBindings`, which is causing one of our tests to fail needlessly. This PR changes the test so that it doesn't care about `ariaRole` one way or the other.