### PR TITLE
add ability to set component qualifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ But if that child element moves somewhere else in the DOM, you're in trouble. So
 {{#each parentArray as |childArray containerIndex|}}
   {{#each childArray as |item index|}}
     <div data-test={{hook "item" index=index containerIndex=containerIndex}}>{{item}}</div>
+    {{!-- or --}}
+    {{my-component hook="item" hookQualifiers=(hash index=index containerIndex=containerIndex)}}
   {{/each}}
 {{/each}}
 ```
@@ -97,6 +99,20 @@ If there's a conflict with the property `hook` on your components, you can chang
 var ENV ={
   emberHook: {
     hookName: 'customHookName'
+  }
+}
+```
+
+### Changing Component Hook Qualifier
+
+If there's a conflict with the property `hookQualifiers` on your components, you can change the property name in your `config/environment` file:
+
+```js
+// config/environment.js
+
+var ENV ={
+  emberHook: {
+    hookQualifierName: 'customHookQualifierName'
   }
 }
 ```

--- a/addon/mixins/hook.js
+++ b/addon/mixins/hook.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import config from 'ember-get-config';
+import decorateHook from 'ember-hook/utils/decorate-hook';
 import delimit from 'ember-hook/utils/delimit';
 import returnWhenTesting from 'ember-hook/utils/return-when-testing';
 
@@ -10,16 +11,18 @@ const {
 } = Ember;
 
 const hookName = get(config, 'emberHook.hookName') || 'hook';
+const hookQualifierName = get(config, 'emberHook.hookQualifierName') || 'hookQualifiers';
 
 export default Mixin.create({
   attributeBindings: ['_hookName:data-test'],
 
-  _hookName: computed(hookName, {
+  _hookName: computed(hookName, hookQualifierName, {
     get() {
       const hook = get(this, hookName);
-      
+      const qualifiers = get(this, hookQualifierName);
+
       if (hook) {
-        return returnWhenTesting(config, delimit(hook));
+        return returnWhenTesting(config, decorateHook(delimit(hook), qualifiers));
       }
     }
   }).readOnly()

--- a/addon/utils/decorate-hook.js
+++ b/addon/utils/decorate-hook.js
@@ -1,6 +1,6 @@
 import generateQualifier from './generate-qualifier';
 
-export default function decorateHook(hook, qualifiers, wrapper = (text) => text) {
+export default function decorateHook(hook, qualifiers = {}, wrapper = (text) => text) {
   return Object.keys(qualifiers).sort().reduce((decoratedHook, key) => {
     return `${decoratedHook}${wrapper(generateQualifier(qualifiers, key))}`;
   }, hook);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-hook",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Yerrr tests be brittle, mattie!!!",
   "directories": {
     "doc": "doc",

--- a/tests/acceptance/hook-test.js
+++ b/tests/acceptance/hook-test.js
@@ -14,7 +14,7 @@ module('Acceptance | hook', {
 });
 
 test('visiting /', function(assert) {
-  assert.expect(8);
+  assert.expect(9);
 
   visit('/');
 
@@ -22,7 +22,8 @@ test('visiting /', function(assert) {
     assert.equal($(hook('title')).text().trim(), 'Ember Hook');
     assert.equal($hook('title').text().trim(), 'Ember Hook');
 
-    assert.equal($hook('component-hook').text().trim(), 'Component');
+    assert.equal($hook('component-hook').length, 3);
+    assert.equal($hook('component-hook', { index: 2 }).text().trim(), 'Component 3');
 
     assert.equal($hook('letter').length, 5, 'gathers all instances when no qualifiers are provided');
     assert.equal($hook('letter', { groupIndex: 0 }).length, 2, 'gathers all instances that satisfy the qualifier');

--- a/tests/dummy/app/helpers/hash.js
+++ b/tests/dummy/app/helpers/hash.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export function hash(params, object) {
+  return object;
+}
+
+export default Ember.Helper.helper(hash);

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,6 +1,8 @@
 <h2 id="title" data-test={{hook "title"}}>Ember Hook</h2>
 
 {{test-component hook="component-hook" text="Component"}}
+{{test-component hook="component-hook" hookQualifiers=(hash index=1) text="Component 2"}}
+{{test-component hook="component-hook" hookQualifiers=(hash index=2) text="Component 3"}}
 
 {{alphabet-component}}
 

--- a/tests/unit/initializers/ember-hook/initialize-test.js
+++ b/tests/unit/initializers/ember-hook/initialize-test.js
@@ -21,8 +21,8 @@ test('applies the `HookMixin` to `Component`', function(assert) {
   initialize();
 
   const { Component } = Ember;
-  const component = Component.create({ hook: 'foo' });
+  const component = Component.create({ hook: 'foo', hookQualifiers: { index: 3 } });
 
   assert.ok(component.get('attributeBindings').indexOf('_hookName:data-test') > -1, 'adds _hookName to the attributeBindings');
-  assert.equal(component.get('_hookName'), `foo${delimiter}`, 'adds the _hookName computed');
+  assert.equal(component.get('_hookName'), `foo${delimiter}index=3${delimiter}`, 'adds the _hookName computed');
 });


### PR DESCRIPTION
@Ticketfly/frontenders @pzuraq @BrianSipple

Currently, the `hook` helper has support for qualifiers, while component hooks do not. This PR fixes that inconsistency by exposing a way for components to also have qualifiers.