### PR TITLE
ember-alpha support

### DIFF
--- a/addon/mixins/hook.js
+++ b/addon/mixins/hook.js
@@ -14,7 +14,13 @@ const hookName = get(config, 'emberHook.hookName') || 'hook';
 const hookQualifierName = get(config, 'emberHook.hookQualifierName') || 'hookQualifiers';
 
 export default Mixin.create({
-  attributeBindings: ['_hookName:data-test'],
+  init() {
+    if (get(this, 'tagName')) {
+      this.attributeBindings.push('_hookName:data-test');
+    }
+
+    this._super(...arguments);
+  },
 
   _hookName: computed(hookName, hookQualifierName, {
     get() {


### PR DESCRIPTION
tagless components cannot have attributeBindings in glimmer2 either by bug or feature.. unsure but it's currently in ember-alpha.


Fixes #26 