### PR TITLE
update ember-get-config

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,15 +2,5 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-hook',
-  
-  included: function(app) {
-    // See: https://github.com/null-null-null/ember-get-config
-    while (app.app) {
-      app = app.app;
-    }
-    this.eachAddonInvoke('included', [app]);
-    this._super.included.apply(this, [app]);
-  }
-  
+  name: 'ember-hook'
 };

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
-    "ember-get-config": "0.1.7"
+    "ember-get-config": "0.1.9"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/unit/initializers/ember-hook/initialize-test.js
+++ b/tests/unit/initializers/ember-hook/initialize-test.js
@@ -20,9 +20,7 @@ test('applies the `HookMixin` to `Component`', function(assert) {
 
   initialize();
 
-  const component = Ember.Component.proto();
-
-  component.setProperties({ hook: 'foo', hookQualifiers: { index: 3 } });
+  const component = Ember.Component.create({ hook: 'foo', hookQualifiers: { index: 3 } });
 
   assert.ok(component.get('attributeBindings').indexOf('_hookName:data-test') > -1, 'adds _hookName to the attributeBindings');
   assert.equal(component.get('_hookName'), `foo${delimiter}index=3${delimiter}`, 'adds the _hookName computed');


### PR DESCRIPTION
@pzuraq @bl4ckm0r3 @zhujy8833 

This PR updates our `ember-get-config` version, which in turn allows us to remove the `included` hook from `index.js`. Along the way, removed the use of the undocumented `proto` function in one of our tests and replaced it with a simple `create`.