### PR TITLE
Add ability to extend existing qualifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,27 @@ $hook('item', { containerIndex: 5 }); // grabs all 'items' contained by the 5th 
 $hook('item'); // grabs all items
 ```
 
+### Extending
+Sometimes, you may want to extend `hookQualifiers` from a parent when passing it to a child. For instance, in the case above, the outer `{{#each}}` might be in one component, and the inner `{{#each}}` might be in a child.
+In that case, the child can extend the parent's `hookQualifiers` adding on the `index` property. This is assuming that the child was given a `hookQualifiers` property
+```hbs
+{{#each childArray as |item index|}}
+  <div data-test={{hook "item" (extend hookQualifiers index=index)}}>{{item}}</div>
+  {{!-- or --}}
+  {{my-component hook="item" hookQualifiers=(extend hookQualifiers index=index)}}
+{{/each}}
+```
+
+In order for this to work, you'll need an `extend` helper, which doesn't exist natively in `Ember` but is very simple to add to your project:
+```js
+import Ember from 'ember';
+const { Helper, assign } = Ember;
+export function extend ([original], newProps) {
+  return assign({}, original, newProps);
+}
+export default Helper.helper(extend);
+```
+
 ### `initialize`
 
 `ember-hook` works out-of-the-box with acceptance tests, but component integration tests present a problem: they do not run initializers. This includes the `ember-hook` initializer that allows you to use the `hook` attribute on a component. To fix this, you'll need to manually run the initializer in your component test:

--- a/addon/helpers/hook.js
+++ b/addon/helpers/hook.js
@@ -6,10 +6,33 @@ import returnWhenTesting from 'ember-hook/utils/return-when-testing';
 
 const { Helper } = Ember;
 
-export default Helper.extend({
-  compute(params, qualifiers = {}) {
-    const [hook] = params;
-
-    return returnWhenTesting(config, decorateHook(delimit(hook), qualifiers));
+/**
+ * Test if an object is empty `Ember.isEmpty` surprisingly doesn't do that
+ * @see {@link https://github.com/emberjs/ember.js/issues/5543}
+ * @see {@link https://github.com/emberjs/ember.js/blob/v2.10.0/packages/ember-metal/lib/is_empty.js}
+ *
+ * @param {Object} obj - the object to test
+ * @returns {Boolean} true if there are no keys on the object
+ */
+function isEmpty (obj = {}) {
+  if (obj === null) {
+    return true;
   }
-});
+
+  return Object.keys(obj).length === 0;
+}
+
+export function hook([hook, qualifierObj = {}], attributes = {}) {
+  if (typeof qualifierObj !== 'object') {
+    throw new Error(`The qualifier object passed to the "hook" helper must be an object not a ${typeof qualifierObj}`);
+  }
+
+  if (!isEmpty(qualifierObj) && !isEmpty(attributes)) {
+    throw new Error('Either provide your own qualifier object, or add attributes to the "hook" helper, not both.');
+  }
+
+  let qualifiers = isEmpty(qualifierObj) ? attributes : qualifierObj;
+  return returnWhenTesting(config, decorateHook(delimit(hook), qualifiers));
+}
+
+export default Helper.helper(hook);

--- a/tests/unit/helpers/hook-test.js
+++ b/tests/unit/helpers/hook-test.js
@@ -1,0 +1,39 @@
+import { hook } from 'dummy/helpers/hook';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | hook');
+
+test('it handles simple case', function(assert) {
+  let result = hook(['myHook']);
+  assert.equal(result, 'myHook&^%^&', 'constructs the hook properly');
+});
+
+test('it handles qualifier attribute case', function(assert) {
+  let result = hook(['myHook'], {foo: 'bar', fizz: 'bang'});
+  assert.equal(result, 'myHook&^%^&fizz=bang&^%^&foo=bar&^%^&', 'constructs the hook properly');
+});
+
+test('it handles qualifier object case', function(assert) {
+  let result = hook(['myHook', {foo: 'bar'}]);
+  assert.equal(result, 'myHook&^%^&foo=bar&^%^&', 'constructs the hook properly');
+});
+
+test('it errors when including both a qualifier object and qualifier attributes', function(assert) {
+  assert.throws(
+    function () {
+      hook(['myHook', {foo: 'bar'}], {fizz: 'bang'});
+    },
+    /Either provide your own qualifier object, or add attributes to the "hook" helper, not both/,
+    'raised error includes proper message'
+  );
+});
+
+test('it errors when passing in a non-object as a qualifer object', function(assert) {
+  assert.throws(
+    function () {
+      hook(['myHook', 'foo-bar'], {fizz: 'bang'});
+    },
+    /The qualifier object passed to the "hook" helper must be an object not a string/,
+    'raised error includes proper message'
+  );
+});


### PR DESCRIPTION
The hook helper will now accept a second parameter which allows you to
extend the hook qualifiers of a parent component.

I'm not sure if this is something you'd consider adding, but we've been using `ember-hook` a lot and realized it's very handy to be able to extend a parent component's `hookQualifiers`.

The current contents of this PR only handle the case where you're directly setting `data-test` or whatever your attribute is and using the `{{hook}}` helper, but if this is something you'd be interested in incorporating, I can include a helper I also wrote that lets you extend `hookQualifiers` from a parent into the `hookQualifiers` property of a child component:

```js
/**
 * The extend helper, used to extend a given object by adding properites from another object
 * to it. The original object is not modified, but rather the properties of all objects are
 * copied onto a new, empty object.
 */
import Ember from 'ember'
const {Helper, assign} = Ember
const {helper} = Helper

export function extend ([original], newProps) {
  return assign({}, original, newProps)
}

export default helper(extend)
```

It's pretty simple (I'd format it to match your helper definitions of course, and add `;`, etc.

Then users can do something like: 
```hbs
{{my-sub-component
  hookQualifiers=(extend hookQualifiers foo='bar')
}}
```