### PR TITLE
Don't set attribute bindings on tagless components

### DIFF
--- a/addon/mixins/hook.js
+++ b/addon/mixins/hook.js
@@ -17,7 +17,7 @@ const hookQualifierName = get(config, 'emberHook.hookQualifierName') || 'hookQua
 export default Mixin.create({
   init() {
     this._super(...arguments);
-    if (this.tagName) {
+    if (this.tagName !== '') {
       let newAttributeBindings = [];
       let bindings = get(this, 'attributeBindings');
   

--- a/addon/mixins/hook.js
+++ b/addon/mixins/hook.js
@@ -17,8 +17,7 @@ const hookQualifierName = get(config, 'emberHook.hookQualifierName') || 'hookQua
 export default Mixin.create({
   init() {
     this._super(...arguments);
-  
-    if (this.tagName || this.elementId) {
+    if (this.tagName) {
       let newAttributeBindings = [];
       let bindings = get(this, 'attributeBindings');
   

--- a/tests/integration/components/tagless-test.js
+++ b/tests/integration/components/tagless-test.js
@@ -1,0 +1,23 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+import {HookMixin} from 'ember-hook';
+
+moduleForComponent('ember-hook', 'Integration | Component | tagless', {
+  integration: true
+});
+
+test('ember-hook does not tag less component', function(assert) {
+
+  this.register('component:tag-less', Ember.Component.extend(HookMixin, {
+    tagName: ''
+  }));
+
+  this.render(hbs`
+    {{#tag-less}}
+      template block text
+    {{/tag-less}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});


### PR DESCRIPTION
Fix tagless check to be more compatible 